### PR TITLE
fix: default social worker designation to "All of Client Services"

### DIFF
--- a/web/app/routes/member.tsx
+++ b/web/app/routes/member.tsx
@@ -764,7 +764,7 @@ export default function MemberPage() {
                                 </p>
                                 <p className="text-sm text-[#4B5563]">
                                     {chatUserProfile?.assignedSocialWorkerName ||
-                                        "No social worker assigned"}{" "}
+                                        "All of Client Services"}{" "}
                                     · {statusLabel(selectedStatus)}
                                 </p>
                             </div>
@@ -803,7 +803,7 @@ export default function MemberPage() {
                                         disabled={isSavingAssignment}
                                     >
                                         <option value="">
-                                            Select social worker
+                                            All of Client Services
                                         </option>
                                         {currentUserProfile?.uid &&
                                         !socialWorkers.some(


### PR DESCRIPTION
Closes #46. Relabels the unassigned/default designation in the patient controls so it reads "All of Client Services" instead of "Select social worker" (dropdown default) and "No social worker assigned" (collapsed header). Purely a UI text change; assignment behavior is unchanged.