### PR TITLE
feat(backend): add events rules/indexes and messages timestamp overrides

### DIFF
--- a/backend/firestore.indexes.json
+++ b/backend/firestore.indexes.json
@@ -189,7 +189,59 @@
                     "order": "DESCENDING"
                 }
             ]
+        },
+        {
+            "collectionGroup": "events",
+            "queryScope": "COLLECTION",
+            "fields": [
+                {
+                    "fieldPath": "date",
+                    "order": "ASCENDING"
+                },
+                {
+                    "fieldPath": "startTime",
+                    "order": "ASCENDING"
+                }
+            ]
+        },
+        {
+            "collectionGroup": "referrals",
+            "queryScope": "COLLECTION",
+            "fields": [
+                {
+                    "fieldPath": "isDeleted",
+                    "order": "ASCENDING"
+                },
+                {
+                    "fieldPath": "dateSubmitted",
+                    "order": "DESCENDING"
+                }
+            ]
         }
     ],
-    "fieldOverrides": []
+    "fieldOverrides": [
+        {
+            "collectionGroup": "messages",
+            "fieldPath": "timestamp",
+            "ttl": false,
+            "indexes": [
+                {
+                    "order": "ASCENDING",
+                    "queryScope": "COLLECTION"
+                },
+                {
+                    "order": "DESCENDING",
+                    "queryScope": "COLLECTION"
+                },
+                {
+                    "arrayConfig": "CONTAINS",
+                    "queryScope": "COLLECTION"
+                },
+                {
+                    "order": "DESCENDING",
+                    "queryScope": "COLLECTION_GROUP"
+                }
+            ]
+        }
+    ]
 }

--- a/backend/firestore.rules
+++ b/backend/firestore.rules
@@ -121,6 +121,11 @@ service cloud.firestore {
       allow create, update, delete: if false;
     }
 
+    match /events/{eventId} {
+      allow read: if signedIn();
+      allow create, update, delete: if false;
+    }
+
     match /{document=**} {
       allow read, write: if false;
     }

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -5,6 +5,9 @@
 /.react-router/
 /build/
 
+# Vite
+/.vite/
+
 #environment files
 .env
 


### PR DESCRIPTION
Backend counterpart to the calendar (#42) and chat search (#43) features, which merged without it.

## Why this is needed

`firestore.rules` ends with a catch-all `match /{document=**} { allow read, write: if false; }`. With no `/events` rule, **every calendar read is denied** — #42 is non-functional without this. Likewise the calendar's `date` + `startTime` query and chat search's collection-group query on `messages.timestamp` have no matching index to run against.

## Changes

- **`events` rule** — signed-in read; create/update/delete stay `false` (writes are server-side only, matching the pattern used by neighboring collections).
- **`events` index** on (`date` ASC, `startTime` ASC) — the calendar's ordered date query.
- **`messages.timestamp` fieldOverrides** incl. `COLLECTION_GROUP` / `DESCENDING` — required by chat search's collection-group query.
- **`referrals` index** on (`isDeleted` ASC, `dateSubmitted` DESC).
- **`web/.gitignore`** — ignore the Vite cache dir, which was showing up as untracked.

## Notes

These rules are **already deployed to Firebase**; this PR brings the repo in line with the deployed state rather than introducing a new change to production.

No conflict with #61 — that PR edits the helper/`users`/`patients` regions of `firestore.rules`; this adds an `events` block those hunks don't touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)